### PR TITLE
Vis distribusjon av svarene per spørsmål

### DIFF
--- a/src/app/team/[groupId]/[teamId]/graph/page.tsx
+++ b/src/app/team/[groupId]/[teamId]/graph/page.tsx
@@ -2,7 +2,7 @@ import * as R from 'remeda'
 import React, { ReactElement, Suspense } from 'react'
 import { Metadata } from 'next'
 
-import { Heading, Skeleton, BodyLong, Detail } from 'aksel-server'
+import { BodyLong, Detail, Heading, Skeleton } from 'aksel-server'
 
 import { TeamNotAccesible, TeamNotFound } from '../../../../../components/errors/ErrorMessages'
 import { userHasAdGroup } from '../../../../../auth/authentication'
@@ -120,20 +120,21 @@ async function PerQuestionGraph({ teamId }: { teamId: string }): Promise<ReactEl
         )
     }
 
-    const { scoredQuestions, maxQuestions, questions } = teamMetrics
+    const earliest = { timestamp: new Date() }
 
-    const earliest = R.minBy(scoredQuestions, (it) => it.timestamp.getTime())
     return (
         <div>
             <Heading size="medium" level="3">
                 Score per spørsmål per uke
             </Heading>
             <Detail>
-                {scoredQuestions.length} målinger siden Uke {getWeekNumber(earliest.timestamp)},{' '}
+                {teamMetrics.length} målinger siden Uke {getWeekNumber(earliest.timestamp)},{' '}
                 {earliest.timestamp.getFullYear()}
             </Detail>
             <div className="mt-4">
-                <ScorePerQuestion maxQuestions={maxQuestions} questions={questions} data={scoredQuestions} />
+                {teamMetrics.map((it) => (
+                    <ScorePerQuestion key={it.question.questionId} question={it.question} scoring={it.scoring} />
+                ))}
             </div>
         </div>
     )

--- a/src/safe-types.ts
+++ b/src/safe-types.ts
@@ -16,3 +16,26 @@ export interface Question {
     type: QuestionType
     custom?: boolean
 }
+
+export type QuestionScoring = {
+    timestamp: Date
+    averageScore: number
+    distribution: QuestionScoreDistributrion
+}
+
+export type QuestionScoreDistributrion = Record<AnswerLevel, number>
+
+export enum AnswerLevel {
+    GOOD = 'GOOD',
+    MEDIUM = 'MEDIUM',
+    BAD = 'BAD',
+}
+
+export type QuestionScorePerWeek = {
+    question: {
+        questionId: string
+        question: string
+        answers: Record<AnswerLevel, string>
+    }
+    scoring: QuestionScoring[]
+}


### PR DESCRIPTION
Viser fordelingen av grønne/gule/røde svar i tillegg til gjennomsnittet.

For å få det til må hvert spørsmål vises med en egen graf

![localhost_3000_team_fake-group_test-id-1_graph](https://github.com/navikt/helsesjekk-bot/assets/588046/af342dad-cb8d-4e89-b805-92b3442f10ca)
